### PR TITLE
Group by enclosing class

### DIFF
--- a/test-distribution-maven-plugin/src/main/java/com/github/seregamorph/testdistribution/maven/SplitMojo.java
+++ b/test-distribution-maven-plugin/src/main/java/com/github/seregamorph/testdistribution/maven/SplitMojo.java
@@ -67,6 +67,9 @@ public class SplitMojo extends AbstractMojo {
     @Parameter(property = "testDistribution.initialSort")
     private boolean initialSort = true;
 
+    @Parameter(property = "testDistribution.outputSort")
+    private boolean outputSort = true;
+
     @Parameter(property = "testDistribution.distributionProvider")
     private String distributionProvider = SimpleDistributionProvider.class.getName();
 
@@ -127,6 +130,11 @@ public class SplitMojo extends AbstractMojo {
         TestDistributionParameters parameters = new TestDistributionParameters(numGroups, getModuleName(),
                 project.getBasedir(), minGroupSize, shiftOffset);
         List<List<String>> testClassesGroups = splitTestClasses(urls, testClassNames, parameters);
+        if (outputSort) {
+            for (List<String> testClassGroup : testClassesGroups) {
+                Collections.sort(testClassGroup);
+            }
+        }
         List<TestGroupEntity> testGroups = new ArrayList<>();
         for (int i = 0; i < testClassesGroups.size(); i++) {
             List<String> testClasses = testClassesGroups.get(i);
@@ -188,7 +196,7 @@ public class SplitMojo extends AbstractMojo {
                     throw new IllegalArgumentException("Test class " + testClassName
                         + " from group " + (i + 1)
                         + " is not present in the discovered test classes list"
-                        + " or dumplicated");
+                        + " or duplicated");
                 }
             }
         }

--- a/test-distribution-provider/src/main/java/com/github/seregamorph/testdistribution/DistributionProvider.java
+++ b/test-distribution-provider/src/main/java/com/github/seregamorph/testdistribution/DistributionProvider.java
@@ -11,10 +11,11 @@ public interface DistributionProvider {
 
     /**
      * Distribute test classes to groups. Each subgroup should preserve the original order of test classes.
+     * All nested classes of the same enclosing class should be in the same subgroup.
      *
      * @param testClassNames
      * @param parameters
-     * @return list of size numGroups containing subsets of original testClasses
+     * @return list of size numGroups containing subsets of original testClasses, this collection should be mutable
      */
     List<List<String>> split(List<String> testClassNames, TestDistributionParameters parameters);
 }

--- a/test-distribution-provider/src/main/java/com/github/seregamorph/testdistribution/SimpleDistributionProvider.java
+++ b/test-distribution-provider/src/main/java/com/github/seregamorph/testdistribution/SimpleDistributionProvider.java
@@ -2,7 +2,10 @@ package com.github.seregamorph.testdistribution;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
 
 /**
  * Simple distribution provider which splits the original list to N groups.
@@ -36,9 +39,27 @@ public class SimpleDistributionProvider implements DistributionProvider {
                 toExclusive = testClasses.size();
             }
             if (fromInclusive < toExclusive) {
-                groups.add(testClasses.subList(fromInclusive, toExclusive));
+                groups.add(new ArrayList<>(testClasses.subList(fromInclusive, toExclusive)));
             } else {
                 groups.add(Collections.emptyList());
+            }
+        }
+
+        // enclosing class name -> first group containing it
+        Map<String, List<String>> firstEnclosingGroup = new TreeMap<>();
+        for (List<String> group : groups) {
+            for (Iterator<String> iterator = group.iterator(); iterator.hasNext(); ) {
+                String testClassName = iterator.next();
+                String enclosingTestClassName = getEnclosingClassName(testClassName);
+                List<String> firstEclosingGroup = firstEnclosingGroup.get(enclosingTestClassName);
+                if (firstEclosingGroup == null) {
+                    firstEnclosingGroup.put(enclosingTestClassName, group);
+                } else if (firstEclosingGroup != group) {
+                    // put all classes with the same enclosing class to the same group
+                    // we need it to properly support behavior of surefire plugin
+                    iterator.remove();
+                    firstEclosingGroup.add(testClassName);
+                }
             }
         }
 
@@ -49,5 +70,14 @@ public class SimpleDistributionProvider implements DistributionProvider {
         result.addAll(groups.subList(0, bucketOffset));
 
         return result;
+    }
+
+    static String getEnclosingClassName(String fullClassName) {
+        int lastDot = fullClassName.lastIndexOf('.');
+        int firstDollar = fullClassName.indexOf('$', lastDot + 1);
+        if (firstDollar == -1) {
+            return fullClassName;
+        }
+        return fullClassName.substring(0, firstDollar);
     }
 }

--- a/test-distribution-provider/src/test/java/com/github/seregamorph/testdistribution/SimpleDistributionProviderTest.java
+++ b/test-distribution-provider/src/test/java/com/github/seregamorph/testdistribution/SimpleDistributionProviderTest.java
@@ -1,5 +1,6 @@
 package com.github.seregamorph.testdistribution;
 
+import static com.github.seregamorph.testdistribution.SimpleDistributionProvider.getEnclosingClassName;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.File;
@@ -11,6 +12,14 @@ class SimpleDistributionProviderTest {
     private static final DistributionProvider DISTRIBUTION_PROVIDER = new SimpleDistributionProvider();
 
     private static final File modulePath = new File("");
+
+    @Test
+    public void shouldGetEnclosingClassName() {
+        assertEquals("Test1", getEnclosingClassName("Test1"));
+        assertEquals("Test1", getEnclosingClassName("Test1$NestedTest"));
+        assertEquals("org.example.Test1", getEnclosingClassName("org.example.Test1"));
+        assertEquals("org.example.Test1", getEnclosingClassName("org.example.Test1$NestedTest"));
+    }
 
     @Test
     public void shouldSplitMinSize1() {

--- a/test-distribution-spring-provider/src/main/java/com/github/seregamorph/testdistribution/spring/SpringDistributionProvider.java
+++ b/test-distribution-spring-provider/src/main/java/com/github/seregamorph/testdistribution/spring/SpringDistributionProvider.java
@@ -132,7 +132,9 @@ public class SpringDistributionProvider implements DistributionProvider {
      * default.
      */
     protected int getNonItOrder() {
-        return 0;
+        // It seems to be more efficient to have high value than 0 for scenarios when there are a lot of
+        // nested test classes (in combination with grouping the distribution by enclosing class)
+        return Integer.MAX_VALUE;
     }
 
     private static Set<Class<?>> filterItClasses(List<Class<?>> testClasses) {


### PR DESCRIPTION
If there are several nested classes of the same enclosing class, they all should be grouped in the same distribution part. Reason: surefire plugin in case of filtering tests by the enclosing class names executes all nested tests altogether, so there is a chance that the same test class will be executed several times